### PR TITLE
Changed error templates to be more understandable

### DIFF
--- a/avocado/templates/error_pages/400.html
+++ b/avocado/templates/error_pages/400.html
@@ -9,9 +9,9 @@
 			<div class="col-lg-8 col-md-10 mx-auto">
 				<div class="site-heading">
 					<h1>400</h1>
-					<span class="subheading">The request you sent was bad.</span>
+					<span class="subheading">Malformed request</span>
 					<span class="meta">
-						Not sure what to tell you, - try again?
+						Something was wrong with the request you attempted. Please go back and try again.
 					</span>
 				</div>
 			</div>
@@ -25,7 +25,7 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-lg-8 col-md-10 mx-auto">
-				Refresh the page and see if that works.
+				Press the back button and try again. 
 			</div>
 		</div>
 	</div>

--- a/avocado/templates/error_pages/403.html
+++ b/avocado/templates/error_pages/403.html
@@ -9,9 +9,9 @@
 			<div class="col-lg-8 col-md-10 mx-auto">
 				<div class="site-heading">
 					<h1>403</h1>
-					<span class="subheading">Nope.avi</span>
+					<span class="subheading">Permission denied</span>
 					<span class="meta">
-						Permission denied here my dude, only authorized people here.
+						You are not authorized to see this page.
 					</span>
 				</div>
 			</div>
@@ -25,7 +25,7 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-lg-8 col-md-10 mx-auto">
-				Just leave this page?
+				You can return to the last page.
 			</div>
 		</div>
 	</div>

--- a/avocado/templates/error_pages/404.html
+++ b/avocado/templates/error_pages/404.html
@@ -9,9 +9,9 @@
 			<div class="col-lg-8 col-md-10 mx-auto">
 				<div class="site-heading">
 					<h1>404</h1>
-					<span class="subheading">Oh no.. The page doesn't exist!</span>
+					<span class="subheading">This page doesn't exist</span>
 					<span class="meta">
-						Jeez, what did you do?!? This page has either never existed or doesn't any longer.
+						This page has either never existed or doesn't any longer.
 					</span>
 				</div>
 			</div>
@@ -25,7 +25,7 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-lg-8 col-md-10 mx-auto">
-				This page just doesn't exist so just press the back button to get back to where you were before you stumbled upon this page. :)
+				Press the back button to go back to the page you were in before.
 			</div>
 		</div>
 	</div>

--- a/avocado/templates/error_pages/500.html
+++ b/avocado/templates/error_pages/500.html
@@ -9,9 +9,9 @@
 			<div class="col-lg-8 col-md-10 mx-auto">
 				<div class="site-heading">
 					<h1>500</h1>
-					<span class="subheading">Server Error?!??@??!?</span>
+					<span class="subheading">Server Error</span>
 					<span class="meta">
-						ngin.....x is broken or something is broken - we're looking into it.
+						There's been some error on our side. We're working on it!
 					</span>
 				</div>
 			</div>
@@ -25,7 +25,7 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-lg-8 col-md-10 mx-auto">
-				There's nothing you can really do, but wait. 
+				Please try again later!
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
I tried to make them generic, so I also changed the titles to their usual ones. If you'd like me to keep the original titles and only change the message so the funny side is still there, I can also do that!

This pull request fixes issue #21 